### PR TITLE
fix: improve CPU usage from needless garbage collection

### DIFF
--- a/rc.lua
+++ b/rc.lua
@@ -6,10 +6,29 @@ local collectgarbage = collectgarbage
 collectgarbage("incremental", 110, 1000)
 pcall(require, "luarocks.loader")
 
+local memory_last_check_count = collectgarbage("count")
+local memory_last_run_time = os.time()
+local memory_growth_factor = 1.1 -- 10% over last
+local memory_long_collection_time = 300 -- five minutes in seconds
+
 local gtimer = require("gears.timer")
 gtimer.start_new(5, function()
-	collectgarbage("collect")
-	collectgarbage("collect")
+	local cur_memory = collectgarbage("count")
+	-- instead of forcing a garbage collection every 5 seconds
+	-- check to see if memory has grown enough since we last ran
+	-- or if we have waited a sificiently long time
+	local elapsed = os.time() - memory_last_run_time
+	local waited_long = elapsed >= memory_long_collection_time
+	local grew_enough = cur_memory > (memory_last_check_count * memory_growth_factor)
+	if grew_enough or waited_long then
+		collectgarbage("collect")
+		collectgarbage("collect")
+		memory_last_run_time = os.time()
+	end
+	-- even if we didn't clear all the memory we would have wanted
+	-- update the current memory usage.
+	-- slow growth is ok so long as it doesn't go unchecked
+	memory_last_check_count = collectgarbage("count")
 	return true
 end)
 


### PR DESCRIPTION
I've been having issues with teh garabe collection timer going off every 5 seconds. my laptop is form 2011 and have 30%-50% cpu usage spikes every tie it runs.

This adds some simple checks to only force run the garbage collection if memory has grown too fast since the last run or if it's waited about 5 minutes.

this has significatly improved my usage experience.